### PR TITLE
general: python3.8 is EOL, switch min version and remove backwards compat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # vvv just an example of excluding stuff from matrix
         # exclude: [{platform: macos-latest, python-version: '3.6'}]
 
@@ -53,6 +53,7 @@ jobs:
     - if: matrix.platform == 'ubuntu-latest'  # no need to compute coverage for other platforms
       uses: actions/upload-artifact@v4
       with:
+        include-hidden-files: true
         name: .coverage.mypy_${{ matrix.platform }}_${{ matrix.python-version }}
         path: .coverage.mypy/
 
@@ -67,7 +68,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - uses: actions/checkout@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ name = "kompress"
 dependencies = [
     "typing_extensions",
 ]
+requires-python = ">=3.9"
 
 ## these need to be set if you're planning to upload to pypi
 description = "pathlib.Path adapters to transparently read data from compressed files and folders"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,3 @@
-target-version = "py38"  # NOTE: inferred from pyproject.toml if present
-
 lint.extend-select = [
     "F",    # flakes rules -- default, but extend just in case
     "E",    # pycodestyle  -- default, but extend just in case

--- a/src/kompress/__init__.py
+++ b/src/kompress/__init__.py
@@ -113,11 +113,7 @@ def _cpath_open(path: Path | str, *args, mode: str = 'rt', **kwargs) -> IO:
     elif name.endswith(Ext.zip):
         zpath = ZipPath(pp)
         [subpath] = args  # meh?
-        if sys.version_info[:2] == (3, 8):
-            if mode == 'rt':
-                mode = 'r'  # ugh, 3.8 doesn't support rt here
-        # TODO pass **kwargs later to support encoding? kinda annoying, 3.8 doesn't support it
-        return (zpath / subpath).open(mode=mode)
+        return (zpath / subpath).open(mode=mode, **kwargs)
     elif name.endswith(Ext.lz4):
         import lz4.frame  # type: ignore
 

--- a/src/kompress/tar.py
+++ b/src/kompress/tar.py
@@ -6,10 +6,11 @@ import os
 import pathlib
 import sys
 import tarfile
+from collections.abc import Generator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from tarfile import TarFile, TarInfo
-from typing import Dict, Generator, Iterator
+from typing import Dict
 
 from typing_extensions import Self
 
@@ -110,10 +111,10 @@ class TarPath(Path):
         assert n is not None, f"path {self} doesn't exist"
         return n
 
-    def is_file(self) -> bool:
+    def is_file(self, *, follow_symlinks: bool = True) -> bool:  # noqa: ARG002
         return self.node.info.isfile()
 
-    def is_dir(self) -> bool:
+    def is_dir(self, *, follow_symlinks: bool = True) -> bool:  # noqa: ARG002
         return self.node.info.isdir()
 
     def exists(self, **kwargs) -> bool:  # noqa: ARG002
@@ -154,7 +155,7 @@ class TarPath(Path):
         if 'b' in mode:  # meh
             return extracted
         else:
-            return io.TextIOWrapper(extracted, encoding=kwargs.get('encoding'))  # type: ignore[arg-type]
+            return io.TextIOWrapper(extracted, encoding=kwargs.get('encoding'))
 
     @staticmethod
     def _make_args(path: Path) -> tuple[TarFile, Nodes, Node]:

--- a/src/kompress/utils.py
+++ b/src/kompress/utils.py
@@ -5,8 +5,9 @@ Helper utils for zippath adapter
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import Iterable, Iterator, List, Tuple
+from typing import List, Tuple
 
 RootName = str
 DirName = str

--- a/src/kompress/zip.py
+++ b/src/kompress/zip.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import os
 import zipfile
+from collections.abc import Iterator, Sequence
 from datetime import datetime
 from functools import total_ordering
 from pathlib import Path
-from typing import Iterator, Sequence
 
 from .utils import walk_paths
 
@@ -15,6 +15,7 @@ class ZipPath(zipfile.Path):
     # NOTE: is_dir/is_file might not behave as expected, the base class checks it only based on the slash in path
 
     _flavour = os.path  # this is necessary for some pathlib operations (in particular python 3.12)
+    parser = os.path  # same but for 3.13
 
     # seems that root/at are not exposed in the docs, so might be an implementation detail
     root: zipfile.CompleteDirs
@@ -69,8 +70,7 @@ class ZipPath(zipfile.Path):
         rpaths = (p for p in rpaths if Path(p).match(glob))
         return (ZipPath(self.root, p) for p in rpaths)
 
-    # TODO remove unused-ignore after 3.8
-    def relative_to(self, other: ZipPath, *extra: str | os.PathLike[str]) -> Path:  # type: ignore[override,unused-ignore]
+    def relative_to(self, other: ZipPath, *extra: str | os.PathLike[str]) -> Path:  # type: ignore[override, unused-ignore]
         assert self.filepath == other.filepath, (self.filepath, other.filepath)
         return self.subpath.relative_to(other.subpath, *extra)
 
@@ -99,7 +99,7 @@ class ZipPath(zipfile.Path):
 
     def iterdir(self) -> Iterator[ZipPath]:
         for s in self._as_dir().iterdir():
-            yield ZipPath(s.root, s.at)  # type: ignore[attr-defined]
+            yield ZipPath(s.root, s.at)
 
     @property
     def stem(self) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -17,19 +17,23 @@ passenv =
     PYTHONPYCACHEPREFIX
     MYPY_CACHE_DIR
     RUFF_CACHE_DIR
+usedevelop = true  # for some reason tox seems to ignore "-e ." in deps section??
+# note: --use-pep517 here is necessary for tox --parallel flag to work properly
+# otherwise it seems that it tries to modify .eggs dir in parallel and it fails
+install_command = {envpython} -m pip install --use-pep517 {opts} {packages}
 
 
 [testenv:ruff]
+deps =
+    -e .[testing]
 commands =
-    {envpython} -m pip install --use-pep517 -e .[testing]
     {envpython} -m ruff check src/
 
 
-# note: --use-pep517 here is necessary for tox --parallel flag to work properly
-# otherwise it seems that it tries to modify .eggs dir in parallel and it fails
 [testenv:tests]
+deps =
+    -e .[testing]
 commands =
-    {envpython} -m pip install --use-pep517 -e .[testing]
     # posargs allow test filtering, e.g. tox ... -- -k test_name
     {envpython} -m pytest \
         --pyargs {[testenv]package_name} \
@@ -37,9 +41,10 @@ commands =
 
 
 [testenv:mypy]
+deps =
+    -e .[testing,zstd]
 commands =
-    {envpython} -m pip install --use-pep517 -e .[testing,zstd]
-    {envpython} -m mypy --install-types --non-interactive \
+    {envpython} -m mypy \
         -p {[testenv]package_name}       \
         # txt report is a bit more convenient to view on CI
         --txt-report  .coverage.mypy     \


### PR DESCRIPTION
also

- clean up tox configuration
- enable 3.13 on CI