### PR TITLE
chore: python3.14 support -- use builtin compression.zstd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13'] # TODO later, '3.14-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14-dev']
         # vvv just an example of excluding stuff from matrix
         # exclude: [{platform: macos-latest, python-version: '3.6'}]
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ This currently supports these archive formats:
 
 - `.xz`
 - `.zip`
-- `.lz4` (`pip install 'kompress[lz4]'`)
-- `.zstd` (`pip install 'kompress[zstd]'`)
 - `.zst`
 - `.tar.gz`
 - `.gz`
+- `.zstd` (since `python3.14`, on older version use `pip install 'kompress[zstd]'`)
+- `.lz4` (`pip install 'kompress[lz4]'`)
 
-If it doesn't recognize the filetype, it will just call `pathlib.Path.open` like normal
+If it doesn't recognize the filetype, it will just call `pathlib.Path.open`, reading it like a regular file.
 
 Originally discussed in this [HPI issue](https://github.com/karlicoss/HPI/issues/20)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ Homepage = "https://github.com/karlicoss/kompress"
 
 [project.optional-dependencies]
 zstd = [
-    "zstandard",
+    # note: python 3.14+ has built-in compression.zstd module
+    "zstandard; python_version < '3.14'",
 ]
 lz4 = [
     "lz4"

--- a/src/kompress/__init__.py
+++ b/src/kompress/__init__.py
@@ -68,8 +68,9 @@ class CPath(Path):
         errors: str | None = None,
         **kwargs,
     ):
-        if buffering != -1:
+        if buffering not in {-1, 0}:
             # buffering is unsupported by most compressed formats
+            # -1 is 'default', 0 means 'buffering off' (pathlib passes it since 3.14)
             warnings.warn(f"while opening {self}: CPath doesn't support buffering", stacklevel=2)
         # simply forward the rest of positional args
         kwargs['encoding'] = encoding
@@ -88,18 +89,28 @@ def _cpath_open(*, path: Path | str, mode: str, **kwargs) -> IO:
     pp = Path(path)
     name = pp.name
     if name.endswith((Ext.zstd, Ext.zst)):
-        import zstandard
+        if sys.version_info[:2] >= (3, 14):
+            from compression import zstd  # type: ignore[attr-defined]
 
-        fh = pp.open('rb')
-        dctx = zstandard.ZstdDecompressor()
-        reader = dctx.stream_reader(fh)
+            # ugh. default r for zstd is rb
+            # see https://docs.python.org/3.15/library/compression.zstd.html#compression.zstd.open
+            if mode == 'r':
+                mode = 'rt'
 
-        if mode == 'rb':
-            return reader
+            return zstd.open(path, mode=mode, **kwargs)
         else:
-            # must be text mode
-            # NOTE: no need to pass mode, TextIOWrapper doesn't like it
-            return io.TextIOWrapper(reader, **kwargs)  # meh
+            import zstandard as zstd
+
+            fh = pp.open('rb')
+            dctx = zstd.ZstdDecompressor()
+            reader = dctx.stream_reader(fh)
+
+            if mode == 'rb':
+                return reader
+            else:
+                # must be text mode
+                # NOTE: no need to pass mode, TextIOWrapper doesn't like it
+                return io.TextIOWrapper(reader, **kwargs)  # meh
     elif name.endswith(Ext.xz):
         import lzma
 

--- a/src/kompress/tests/kompress.py
+++ b/src/kompress/tests/kompress.py
@@ -1,6 +1,7 @@
 import gzip
 import io
 import lzma
+import sys
 import zipfile
 from pathlib import Path
 
@@ -50,6 +51,10 @@ def test_cpath_regular(filename: str, expected: str, tmp_path: Path) -> None:
     Check different ways of interacting with CPath
     """
     path = tmp_path / filename
+
+    if path.suffix == '.lz4':
+        if sys.version_info[:2] >= (3, 14):
+            pytest.skip("lz4 bindings are broken atm for 3.14+, see https://github.com/python-lz4/python-lz4/issues/302")
 
     with CPath(path).open() as fo:
         assert fo.read() == expected
@@ -239,10 +244,16 @@ def prepare_data(tmp_path: Path):
             lzf.write(b'compressed text')
 
     # zst
-    import zstandard as zstd
+    if sys.version_info[:2] >= (3, 14):
+        from compression import zstd  # type: ignore[attr-defined]
 
-    zst_ctx = zstd.ZstdCompressor()
-    (tmp_path / 'file.zst').write_bytes(zst_ctx.compress(b'compressed text'))
+        with zstd.open(tmp_path / 'file.zst', 'wb') as f:
+            f.write(b'compressed text')
+    else:
+        import zstandard as zstd
+
+        zst_ctx = zstd.ZstdCompressor()
+        (tmp_path / 'file.zst').write_bytes(zst_ctx.compress(b'compressed text'))
 
     # gz
     gzf = tmp_path / 'file.gz'
@@ -250,9 +261,12 @@ def prepare_data(tmp_path: Path):
         f.write(b'compressed text')
 
     # lz4
-    import lz4.frame  # type: ignore[import-untyped]
+    if sys.version_info[:2] < (3, 14):
+        # lz4 bindings are broken atm for 3.14
+        # see https://github.com/python-lz4/python-lz4/issues/302
+        import lz4.frame  # type: ignore[import-untyped]
 
-    (tmp_path / 'file.lz4').write_bytes(lz4.frame.compress(b'compressed text'))
+        (tmp_path / 'file.lz4').write_bytes(lz4.frame.compress(b'compressed text'))
 
     with zipfile.ZipFile(tmp_path / 'file.zip', 'w') as zf:
         zf.writestr('path/in/archive', 'data in zip')

--- a/src/kompress/utils.py
+++ b/src/kompress/utils.py
@@ -88,21 +88,17 @@ def test_walk_paths_basic() -> None:
     ]
 
     # one empty dir
-    # fmt: off
     assert list(walk_paths(['aaa/'], separator='/')) == [
         ('.'  , ['aaa'], []),
         ('aaa', []     , []),
-    ]
-    # fmt: on
+    ]  # fmt: skip
 
     # dir with one dir with one file
-    # fmt: off
     assert list(walk_paths(['aaa/', 'aaa/bbb/', 'aaa/bbb/fff'], separator='/')) == [
         ('.'      , ['aaa'], []),
         ('aaa'    , ['bbb'], []),
         ('aaa/bbb', []     , ['fff']),
-    ]
-    # fmt: on
+    ]  # fmt: skip
 
 
 def test_walk_paths_against_stdlib() -> None:


### PR DESCRIPTION
note that lz4 seems to be broken on 3.14 for now