### PR TITLE
deprecate python 3.10/3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
         # vvv just an example of excluding stuff from matrix
         # exclude: [{platform: macos-latest, python-version: '3.6'}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "kompress"
 dependencies = [
     "typing_extensions",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 ## these are only useful for pypi
 description = "pathlib.Path adapters to transparently read data from compressed files and folders"  # shows on project page/in search
@@ -164,7 +164,7 @@ lint.ignore = [
     "PERF401",
 
     # suggests no using exception in for loops
-    # we do use this technique a lot, plus in 3.11 happy path exception handling is "zero-cost"
+    # we do use this technique a lot, plus since 3.11 happy path exception handling is "zero-cost"
     "PERF203",
 
     "RET504", # unnecessary assignment before returning -- that can be useful for readability

--- a/src/kompress/__init__.py
+++ b/src/kompress/__init__.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import gzip
 import io
-import os
-import pathlib
 import sys
 import warnings
 from pathlib import Path
@@ -41,10 +39,6 @@ class CPath(Path):
     Path only has _accessor and _closed slots, so can't directly set .open method
     _accessor.open has to return file descriptor, doesn't work for compressed stuff.
     """
-
-    if sys.version_info[:2] < (3, 12):
-        # older version of python need _flavour defined
-        _flavour = pathlib._windows_flavour if os.name == 'nt' else pathlib._posix_flavour  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
     def __new__(cls, *args, **kwargs):
         # TODO shortcut if args[0] is already Cpath?

--- a/src/kompress/tar.py
+++ b/src/kompress/tar.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 import fnmatch
 import io
 import os
-import pathlib
-import sys
 import tarfile
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from tarfile import TarFile, TarInfo
-
-from typing_extensions import Self
+from typing import Self
 
 from .utils import walk_paths
 
@@ -39,10 +36,6 @@ def _tarpath(tf: TarFile) -> Path:
 
 
 class TarPath(Path):
-    if sys.version_info[:2] < (3, 12):
-        # older version of python need _flavour defined
-        _flavour = pathlib._windows_flavour if os.name == 'nt' else pathlib._posix_flavour  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
-
     def __new__(
         cls,
         tar: str | Path | TarPath | TarFile,
@@ -90,10 +83,8 @@ class TarPath(Path):
         assert _nodes is not None
         assert _rpath is not None
 
-        if sys.version_info[:2] >= (3, 12):
-            # in older version of python Path didn't have __init__, so this just calls object.__init__
-            path = _tarpath(tar) / _rpath
-            super().__init__(path)
+        path = _tarpath(tar) / _rpath
+        super().__init__(path)
 
         self.tar = tar
         self._nodes = _nodes

--- a/src/kompress/tests/kompress.py
+++ b/src/kompress/tests/kompress.py
@@ -268,7 +268,3 @@ def prepare_data(tmp_path: Path):
 
     with zipfile.ZipFile(tmp_path / 'file.zip', 'w') as zf:
         zf.writestr('path/in/archive', 'data in zip')
-    try:
-        yield None
-    finally:
-        pass

--- a/src/kompress/utils.py
+++ b/src/kompress/utils.py
@@ -102,13 +102,6 @@ def test_walk_paths_basic() -> None:
 
 
 def test_walk_paths_against_stdlib() -> None:
-    import sys
-
-    import pytest
-
-    if sys.version_info[:2] < (3, 12):
-        pytest.skip("pathlib.Path.walk is only present from python 3.12")
-
     def as_paths(root: Path) -> Iterator[str]:
         for r, dirs, files in root.walk():
             rr = r.relative_to(root)

--- a/src/kompress/zip.py
+++ b/src/kompress/zip.py
@@ -63,14 +63,14 @@ class ZipPath(zipfile.Path):
         # note: seems that zip always uses forward slash, regardless OS?
         return zipfile.Path(self.root, self.at + '/')
 
-    def rglob(self, glob: str) -> Iterator[ZipPath]:
+    def rglob(self, pattern: str) -> Iterator[ZipPath]:
         # note: not 100% sure about the correctness, but seem fine?
         # Path.match() matches from the right, so need to
         rpaths = (p for p in self.root.namelist() if p.startswith(self.at))
-        rpaths = (p for p in rpaths if Path(p).match(glob))
+        rpaths = (p for p in rpaths if Path(p).match(pattern))
         return (ZipPath(self.root, p) for p in rpaths)
 
-    def relative_to(self, other: ZipPath, *extra: str | os.PathLike[str]) -> Path:  # type: ignore[override, unused-ignore]
+    def relative_to(self, other: ZipPath, *extra: str | os.PathLike[str]) -> Path:  # type: ignore[override, unused-ignore]  # ty: ignore[invalid-method-override]
         assert self.filepath == other.filepath, (self.filepath, other.filepath)
         return self.subpath.relative_to(other.subpath.joinpath(*extra))
 


### PR DESCRIPTION
3.10 is nearing EOL and deprecating 3.11 allows removing some nasty hacks

If necessary should be possible to use a previous release for 3.10/3.11