### PR TITLE
zip: some minor impovements and tests cleanup

### DIFF
--- a/src/kompress/__init__.py
+++ b/src/kompress/__init__.py
@@ -79,7 +79,7 @@ class CPath(Path):
 
 def _cpath_open(*, path: Path | str, mode: str, **kwargs) -> IO:
     if 'w' in mode:
-        raise RuntimeError(f"Tring to open {path} in {mode=}. CPath only supports reading.")
+        raise RuntimeError(f"Trying to open {path} in {mode=}. CPath only supports reading.")
 
     pp = Path(path)
     name = pp.name

--- a/src/kompress/tests/archive_path.py
+++ b/src/kompress/tests/archive_path.py
@@ -1,3 +1,10 @@
+"""
+Shared archive-path tests.
+
+These cases are expected to pass for regular directories, ZIP archives, and tar.gz archives.
+Format-specific edge cases belong next to the corresponding path implementation instead.
+"""
+
 from __future__ import annotations
 
 import io
@@ -5,7 +12,6 @@ import tarfile
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -15,6 +21,7 @@ structure_data: Path = Path(__file__).parent / "structure_data"
 
 
 ArchiveEntries = dict[str, bytes | None]
+GDPR_EXPORT_KINDS = ['directory', 'zip', 'tar.gz']
 
 
 GDPR_EXPORT_ENTRIES: ArchiveEntries = {
@@ -40,6 +47,45 @@ def _write_directory(target: Path, entries: ArchiveEntries) -> Path:
     return target
 
 
+def _write_archive(target: Path, kind: str, entries: ArchiveEntries) -> Path:
+    if kind == 'zip':
+        with zipfile.ZipFile(target, 'w') as z:
+            for name, data in entries.items():
+                if data is None:
+                    z.writestr(name.rstrip('/') + '/', '')
+                else:
+                    z.writestr(name, data)
+    elif kind == 'tar.gz':
+        with tarfile.open(target, 'w:gz') as t:
+            for name, data in entries.items():
+                if data is None:
+                    info = tarfile.TarInfo(name.rstrip('/'))
+                    info.type = tarfile.DIRTYPE
+                else:
+                    info = tarfile.TarInfo(name)
+                    info.size = len(data)
+
+                info.mode = 0o755 if data is None else 0o644
+                if data is None:
+                    t.addfile(info)
+                else:
+                    t.addfile(info, io.BytesIO(data))
+    else:
+        raise AssertionError(kind)
+
+    assert target.exists()
+    return target
+
+
+def _gdpr_export_target(kind: str, tmp_path: Path) -> Path:
+    if kind == 'directory':
+        return _write_directory(tmp_path / 'gdpr_export_directory', GDPR_EXPORT_ENTRIES)
+
+    target = structure_data / f'gdpr_export.{kind}'
+    assert target.exists(), target  # precondition
+    return target
+
+
 def _normalized_walk(root: Path) -> list[tuple[Path, list[str], list[str]]]:
     """
     Compare walk output across backends without depending on absolute temp paths or filesystem ordering.
@@ -56,46 +102,104 @@ def path_factory(request: pytest.FixtureRequest, tmp_path: Path) -> Callable[[Ar
             return _write_directory(tmp_path / 'directory', entries)
 
         target = tmp_path / f'archive.{kind}'
-
-        if kind == 'zip':
-            with zipfile.ZipFile(target, 'w') as z:
-                for name, data in entries.items():
-                    if data is None:
-                        z.writestr(name.rstrip('/') + '/', '')
-                    else:
-                        z.writestr(name, data)
-        elif kind == 'tar.gz':
-            with tarfile.open(target, 'w:gz') as t:
-                for name, data in entries.items():
-                    if data is None:
-                        info = tarfile.TarInfo(name.rstrip('/'))
-                        info.type = tarfile.DIRTYPE
-                    else:
-                        info = tarfile.TarInfo(name)
-                        info.size = len(data)
-
-                    info.mode = 0o755 if data is None else 0o644
-                    if data is None:
-                        t.addfile(info)
-                    else:
-                        t.addfile(info, io.BytesIO(data))
-        else:
-            raise AssertionError(kind)
-
-        assert target.exists()
-        return CPath(target)
+        return CPath(_write_archive(target, kind, entries))
 
     return make_path
 
 
-@pytest.fixture(params=['directory', 'zip', 'tar.gz'])
+@pytest.fixture(params=GDPR_EXPORT_KINDS)
 def gdpr_export(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
-    if request.param == 'directory':
-        return _write_directory(tmp_path / 'gdpr_export_directory', GDPR_EXPORT_ENTRIES)
+    kind = request.param
+    target = _gdpr_export_target(kind, tmp_path)
+    return target if kind == 'directory' else CPath(target)
 
-    target = structure_data / f'gdpr_export.{request.param}'
-    assert target.exists(), target  # precondition
-    return CPath(target)
+
+def test_file_read_modes(gdpr_export: Path) -> None:
+    member = 'gdpr_export/messages/index.csv'
+    path = gdpr_export / member
+
+    assert path.read_text() == 'test message\n'
+    assert path.read_bytes() == b'test message\n'
+
+    assert path.open(mode='rb').read() == b'test message\n'
+    assert path.open(mode='r').read() == 'test message\n'
+    assert path.open(mode='rt').read() == 'test message\n'
+
+
+@pytest.mark.parametrize(
+    ('kind', 'path_type'),
+    [
+        pytest.param('directory', CPath  , id='directory'),
+        pytest.param('zip'      , ZipPath, id='zip'),
+        pytest.param('tar.gz'   , TarPath, id='tar.gz'),
+    ],
+)  # fmt: skip
+def test_cpath_existing_path_dispatch(
+    tmp_path: Path,
+    kind: str,
+    path_type: type[Path],
+) -> None:
+    target = _gdpr_export_target(kind, tmp_path)
+
+    cpath = CPath(target)
+    assert isinstance(cpath, path_type)
+
+    file = cpath / 'gdpr_export/messages/index.csv'
+    assert file.exists()
+    assert file.read_text() == 'test message\n'
+
+    assert isinstance(CPath(*cpath.parts), path_type)
+    assert isinstance(CPath(cpath), path_type)
+
+
+@pytest.mark.parametrize(
+    ('kind', 'path_type'),
+    [
+        pytest.param('directory', Path   , id='directory'),
+        pytest.param('zip'      , ZipPath, id='zip'),
+        pytest.param('tar.gz'   , TarPath, id='tar.gz'),
+    ],
+)  # fmt: skip
+def test_pathlib_compatibility(
+    tmp_path: Path,
+    kind: str,
+    path_type: type[Path],
+) -> None:
+    target = _gdpr_export_target(kind, tmp_path)
+    archive: Path | ZipPath | TarPath
+    if kind == 'zip':
+        archive = ZipPath(target)
+        ZipPath(archive)  # make sure double wrapping doesn't crash
+    elif kind == 'tar.gz':
+        archive = TarPath(target)
+        TarPath(archive)  # make sure double wrapping doesn't crash
+    else:
+        archive = Path(target)
+        Path(archive)  # make sure double wrapping doesn't crash
+
+    # magic! convenient to make third party libraries agnostic of CPath/ZipPath etc
+    assert isinstance(archive, Path)
+    assert isinstance(archive, path_type)
+    assert isinstance(archive / 'subpath', Path)
+
+    assert path_type(target) == path_type(target)
+    assert archive.absolute() == archive
+    assert archive / '.' == archive
+
+    # shouldn't crash
+    hash(archive)
+
+    assert (archive / Path('gdpr_export', 'comments')).exists()
+    # check str constructor just in case
+    archive_from_str = path_type(str(target))
+    assert (archive_from_str / 'gdpr_export' / 'comments').exists()
+    assert not (archive_from_str / 'whatever').exists()
+
+
+def test_dot_segments(gdpr_export: Path) -> None:
+    assert gdpr_export / '.' == gdpr_export
+    assert (gdpr_export / '.' / 'gdpr_export').exists()
+    assert (gdpr_export / 'gdpr_export' / './comments').exists()
 
 
 def test_walk_empty(path_factory: Callable[[ArchiveEntries], Path]) -> None:
@@ -208,8 +312,27 @@ def test_file_type_methods(gdpr_export: Path) -> None:
     assert not missing.is_dir()
     assert not missing.is_file()
 
+    missing_nested = gdpr_export / 'gdpr_export' / 'path' / 'notin' / 'archive'
+    assert not missing_nested.exists()
+    assert not missing_nested.is_dir()
+    assert not missing_nested.is_file()
 
-def test_rglob_relative_to_iterdir(gdpr_export: Path) -> None:
+
+def test_suffixes(gdpr_export: Path) -> None:
+    path = gdpr_export / 'gdpr_export' / 'comments' / 'comments.json.gz'
+
+    assert path.suffixes == ['.json', '.gz']
+    assert path.suffix == '.gz'
+
+
+def test_tree_navigation(gdpr_export: Path) -> None:
+    """
+    Exercise pathlib-style navigation over an archive-backed directory.
+
+    This groups a few related operations over the same GDPR export tree: recursive globbing,
+    converting archive members back to paths relative to an archive subdirectory, matching a
+    directory by pattern, and listing immediate children while preserving the archive path type.
+    """
     archive_path_type = type(gdpr_export)
 
     jsons = [p.relative_to(gdpr_export / 'gdpr_export') for p in gdpr_export.rglob('*.json')]
@@ -324,6 +447,7 @@ def test_missing_archive_is_cpath(tmp_path: Path, filename: str) -> None:
     assert not target.exists()
     assert isinstance(path, CPath)
     assert not path.exists()
+    assert not (path / 'path/in/archive').exists()
 
 
 @pytest.mark.parametrize(
@@ -346,16 +470,10 @@ def test_missing_archive_path_falls_back_to_regular_path(
     assert type(path) is type(tmp_path / filename)
     assert not path.exists()
 
-
-def test_missing_zippath_with_member_falls_back_to_regular_path(tmp_path: Path) -> None:
-    target = tmp_path / 'missing.zip'
-
-    path = cast(Path, ZipPath(target, 'member.txt'))
-
-    assert not target.exists()
-    assert type(path) is type(tmp_path)
-    assert path == target / 'member.txt'
-    assert not path.exists()
+    member = path / 'member.txt'
+    assert type(member) is type(tmp_path / filename)
+    assert member == target / 'member.txt'
+    assert not member.exists()
 
 
 def test_stat_size(gdpr_export: Path) -> None:
@@ -364,17 +482,7 @@ def test_stat_size(gdpr_export: Path) -> None:
     assert path.stat().st_size == len(path.read_bytes())
 
 
-def test_zip_stat_uses_archive_file_when_datetime_is_default(tmp_path: Path) -> None:
-    """
-    ZIP entries can use 1980-01-01 as a placeholder when Python can't read their real timestamp.
-    In that case, ZipPath.stat() falls back to the archive file's stat instead of reporting the placeholder date.
-    """
-    target = tmp_path / 'archive.zip'
-    info = zipfile.ZipInfo('file.txt')
+def test_stat_reports_file_datetime(gdpr_export: Path) -> None:
+    path = gdpr_export / 'gdpr_export' / 'comments' / 'comments.json'
 
-    with zipfile.ZipFile(target, 'w') as z:
-        z.writestr(info, b'abc')
-
-    path = CPath(target) / 'file.txt'
-
-    assert path.stat() == target.stat()
+    assert path.stat().st_mtime > 1625000000

--- a/src/kompress/tests/kompress.py
+++ b/src/kompress/tests/kompress.py
@@ -7,33 +7,9 @@ from pathlib import Path
 
 import pytest
 
-from .. import CPath, ZipPath
+from .. import CPath
 
 structure_data: Path = Path(__file__).parent / "structure_data"
-
-
-def test_zip(tmp_path: Path) -> None:
-    subpath = 'path/in/archive'
-
-    assert (CPath(tmp_path / 'file.zip') / subpath).open().read() == 'data in zip'
-
-    # CPath should dispatch zips to ZipPath
-    cpath = CPath(tmp_path / 'file.zip')
-    assert isinstance(cpath, ZipPath)
-
-    assert (cpath / subpath).read_text() == 'data in zip'
-
-    # make sure construction from parts works as expected
-    assert isinstance(CPath(*cpath.parts), ZipPath)
-
-    assert isinstance(CPath(cpath), ZipPath)
-
-
-def test_cpath_zip(tmp_path: Path) -> None:
-    assert (CPath(tmp_path / 'file.zip') / 'path/in/archive').exists()
-    assert not (CPath(tmp_path / 'file.zip') / 'path/notin/archive').exists()
-
-    assert not (CPath(tmp_path / 'nosuchzip.zip') / 'path/in/archive').exists()
 
 
 @pytest.mark.parametrize(
@@ -78,113 +54,6 @@ def test_cpath_regular(filename: str, expected: str, tmp_path: Path) -> None:
     ]:
         Path(*args)  # type: ignore[misc] # just a sanity check that regular Path can be constructed this way
         assert CPath(*args).read_text() == expected  # type: ignore[misc]
-
-
-def test_zippath(tmp_path: Path) -> None:
-    # TODO support later...
-    # zz = ZipPath(tmp_path / 'doesntexist.zip')
-
-    zp = ZipPath(tmp_path / 'file.zip', 'path/in/archive')
-
-    assert zp.read_text() == 'data in zip'
-
-    assert zp.open(mode='rb').read() == b'data in zip'
-
-    assert zp.open(mode='r').read() == 'data in zip'
-    assert zp.open(mode='rt').read() == 'data in zip'  # type: ignore[call-overload]  # ty: ignore[no-matching-overload]
-
-    target = structure_data / 'gdpr_export.zip'
-    assert target.exists(), target  # precondition
-
-    zp = ZipPath(target)
-
-    ZipPath(zp)  # make sure it doesn't crash
-
-    # magic! convenient to make third party libraries agnostic of ZipPath
-    assert isinstance(zp, Path)
-    assert isinstance(zp, ZipPath)
-    assert isinstance(zp / 'subpath', Path)
-    # TODO maybe change __str__/__repr__? since it's a bit misleading:
-    # Path('/code/hpi/tests/core/structure_data/gdpr_export.zip', 'gdpr_export/')
-
-    assert ZipPath(target) == ZipPath(target)
-    assert zp.absolute() == zp
-    assert zp / '.' == zp
-
-    # shouldn't crash
-    hash(zp)
-
-    assert zp.exists()
-    assert (zp / 'gdpr_export').exists()
-    assert (zp / 'gdpr_export' / 'comments').exists()
-    assert (zp / Path('gdpr_export', 'comments')).exists()
-    ## NOTE: in pathlib.Path these work, however not in zipfile.Path
-    ## for now we don't support them either, need to be really careful if we wanna diverge from zipfile.Path
-    ## but in
-    # assert (zp / '.').exists()
-    # assert (zp / '.' / 'gdpr_export').exists()
-    # assert (zp / 'gdpr_export' / './comments').exists()
-    ##
-
-    # check str constructor just in case
-    assert (ZipPath(str(target)) / 'gdpr_export' / 'comments').exists()
-    assert not (ZipPath(str(target)) / 'whatever').exists()
-
-    matched = list(zp.rglob('*'))
-    assert len(matched) > 0
-    assert all(p.filepath == target for p in matched), matched
-
-    rpaths = [p.relative_to(zp) for p in matched]
-    gdpr_export = Path('gdpr_export')
-    # fmt: off
-    assert rpaths == [
-        gdpr_export,
-        gdpr_export / 'comments',
-        gdpr_export / 'comments' / 'comments.json',
-        gdpr_export / 'profile',
-        gdpr_export / 'profile' / 'settings.json',
-        gdpr_export / 'messages',
-        gdpr_export / 'messages' / 'index.csv',
-    ], rpaths
-    # fmt: on
-
-    # TODO hmm this doesn't work atm, whereas Path does
-    # not sure if it should be defensive or something...
-    # ZipPath('doesnotexist')
-    # same for this one
-    # assert ZipPath(Path('test'), 'whatever').absolute() == ZipPath(Path('test').absolute(), 'whatever')
-
-    assert (ZipPath(target) / 'gdpr_export' / 'comments').exists()
-
-    jsons = [p.relative_to(zp / 'gdpr_export') for p in zp.rglob('*.json')]
-    # fmt: off
-    assert jsons == [
-        Path('comments', 'comments.json'),
-        Path('profile' , 'settings.json'),
-    ]
-    # fmt: on
-    assert (zp / 'gdpr_export' / 'comments' / 'comments.json').relative_to(zp, 'gdpr_export') == Path(
-        'comments',
-        'comments.json',
-    )
-
-    # NOTE: hmm interesting, seems that ZipPath is happy with forward slash regardless OS?
-    assert list(zp.rglob('mes*')) == [ZipPath(target, 'gdpr_export/messages')]
-
-    iterdir_res = list((zp / 'gdpr_export').iterdir())
-    assert len(iterdir_res) == 3
-    assert all(isinstance(p, Path) for p in iterdir_res)
-
-    # date recorded in the zip archive
-    assert (zp / 'gdpr_export' / 'comments' / 'comments.json').stat().st_mtime > 1625000000
-    # TODO ugh.
-    # unzip -l shows the date  as 2021-07-01 09:43
-    # however, python reads it as 2021-07-01 01:43 ??
-    # don't really feel like dealing with this for now, it's not tz aware anyway
-
-    json_gz = zp / 'gdpr_export' / 'comments' / 'comments.json.gz'
-    assert json_gz.suffixes == ['.json', '.gz']
-    assert json_gz.suffix == '.gz'
 
 
 def test_gz(tmp_path: Path) -> None:

--- a/src/kompress/tests/zip.py
+++ b/src/kompress/tests/zip.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import cast
+
+from .. import ZipPath
+
+structure_data: Path = Path(__file__).parent / "structure_data"
+
+
+def test_zippath_direct_member_constructor_read_modes() -> None:
+    path = ZipPath(structure_data / 'gdpr_export.zip', 'gdpr_export/messages/index.csv')
+
+    assert path.read_text() == 'test message\n'
+    assert path.open(mode='rb').read() == b'test message\n'
+    assert path.open(mode='r').read() == 'test message\n'
+
+
+def test_missing_zip_member_constructor_falls_back_to_regular_path(tmp_path: Path) -> None:
+    target = tmp_path / 'missing.zip'
+
+    path = cast(Path, ZipPath(target, 'member.txt'))
+
+    assert not target.exists()
+    assert type(path) is type(tmp_path)
+    assert path == target / 'member.txt'
+    assert not path.exists()
+
+
+def test_zip_stat_uses_archive_file_when_datetime_is_default(tmp_path: Path) -> None:
+    """
+    ZIP entries can use 1980-01-01 as a placeholder when Python can't read their real timestamp.
+    In that case, ZipPath.stat() falls back to the archive file's stat instead of reporting the placeholder date.
+    """
+    target = tmp_path / 'archive.zip'
+    info = zipfile.ZipInfo('file.txt')
+
+    with zipfile.ZipFile(target, 'w') as z:
+        z.writestr(info, b'abc')
+
+    path = ZipPath(target) / 'file.txt'
+
+    assert path.stat() == target.stat()

--- a/src/kompress/zip.py
+++ b/src/kompress/zip.py
@@ -12,9 +12,23 @@ from typing import Self
 from .utils import walk_paths
 
 
+def _without_dot_segments(at: str) -> str:
+    if at in {'', '.'}:
+        return ''
+
+    trailing_slash = at.endswith('/')
+    parts = [part for part in at.split('/') if part not in {'', '.'}]
+    normalized = '/'.join(parts)
+    if trailing_slash and normalized != '':
+        normalized += '/'
+    return normalized
+
+
 @total_ordering
 class ZipPath(zipfile.Path):
     # NOTE: is_dir/is_file might not behave as expected, the base class checks it only based on the slash in path
+    # TODO: maybe change __str__/__repr__; inherited zipfile.Path output is misleading here,
+    # e.g. Path('.../gdpr_export.zip', '') and a trailing slash for the archive root.
 
     _flavour = os.path  # this is necessary for some pathlib operations (in particular python 3.12)
     parser = os.path  # same but for 3.13
@@ -41,7 +55,7 @@ class ZipPath(zipfile.Path):
             at_ = root.at
         else:
             root_ = root
-            at_ = at
+            at_ = _without_dot_segments(at)
 
         super().__init__(root_, at_)
 
@@ -162,6 +176,9 @@ class ZipPath(zipfile.Path):
             # So the best we can do in that case (which still might be wrong is taking the file's stats instead :( )
             return self.filepath.stat()
 
+        # TODO: prefer the UT extra field when present, to better match an extracted regular file.
+        # For gdpr_export/comments/comments.json, unzip -l reports 2021-07-01 09:43 from that
+        # extra field, while zipfile exposes the central-directory DOS timestamp as 01:43.
         dt = datetime(*info.date_time)
         ts = int(dt.timestamp())
         params = {


### PR DESCRIPTION
zip: support dots in subpaths

tests: extract all common stuff to .zip and .tar.gz in archive_path.py; also
  cover plain directories so consistency is checked