### PR TITLE
Improve archive path traversal and glob semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-`kompress` lets you transparently decompress common archive formats while using `pathlib.Path` objects.
+`kompress` lets you transparently read common compressed files and archives through a `pathlib.Paht`-like interface.
 
-It attempts to keep the API as close to pathlib, but things may not be perfect yet
+It attempts to keep the API as close to `pathlib` as practical, but only supports read-oriented operations.
 
 The common case for this is:
 
-- You have a compressed file that when decompressed contains some text
-- You have a function (perhaps from another library, that you don't control), that knows how to take a `pathlib.Path` object and call `.read()` or `.read_text()` on it
+- You have a compressed file that contains some text
+- You have a function (perhaps from another library that you don't control) that accepts a `pathlib.Path` object and calls `.open()`, `.read_text()`, or `.read_bytes()` on it
 
 Without wrapping the function or adding logic to let it read from compressed files, this lets you do the following:
 
 ```python
 from pathlib import Path
-from kompress import CPath, is_compressed
+from kompress import CPath
 
 def char_count(path: Path) -> int:
     # here, if a CPath is passed, it decompresses and returns a string
@@ -21,15 +21,30 @@ inp = input("Enter a file to process: ")  # file came from user
 char_count(CPath(inp))
 ```
 
-This currently supports these archive formats:
+For formats containing a directory tree, select a member with the usual `/` operator:
 
-- `.xz`
-- `.zip`
-- `.zst`
-- `.tar.gz`
+```python
+export = CPath("export.tar.xz")
+settings = export / "profile" / "settings.json"
+print(settings.read_text())
+```
+
+Supported single-file compression formats:
+
 - `.gz`
-- `.zstd` (since `python3.14`, on older version use `pip install 'kompress[zstd]'`)
-- `.lz4` (`pip install 'kompress[lz4]'`)
+- `.bz2`
+- `.xz`
+- `.zst` and `.zstd` (on Python older than 3.14, install `kompress[zstd]`)
+- `.lz4` (install `kompress[lz4]`)
+
+Supported archive formats:
+
+- `.zip`
+- `.tar`
+- `.tgz` and `.tar.gz`
+- `.tar.bz2`
+- `.tar.xz`
+- `.tar.zst` (Python 3.14 or newer)
 
 If it doesn't recognize the filetype, it will just call `pathlib.Path.open`, reading it like a regular file.
 
@@ -38,4 +53,3 @@ Originally discussed in this [HPI issue](https://github.com/karlicoss/HPI/issues
 ## Installing
 
 `pip install kompress`
-

--- a/src/kompress/tar.py
+++ b/src/kompress/tar.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import fnmatch
 import io
 import os
 import sys
@@ -11,7 +10,7 @@ from pathlib import Path
 from tarfile import TarFile, TarInfo
 from typing import Self
 
-from .utils import walk_paths
+from .utils import archive_glob, walk_paths
 
 
 @dataclass(slots=True)
@@ -21,7 +20,8 @@ class Node:
 
     @property
     def name(self) -> str:
-        return self.info.name.rsplit('/', maxsplit=1)[-1]
+        # Tar directory entries may retain a trailing '/', which would otherwise make their name empty.
+        return self.info.name.rstrip('/').rsplit('/', maxsplit=1)[-1]
 
 
 Nodes = dict[str, Node]
@@ -167,27 +167,11 @@ class TarPath(Path):
                 follow_symlinks=follow_symlinks,
             )
 
-    def glob(self, pattern: str, **kwargs) -> Iterator[TarPath]:  # type: ignore[override, unused-ignore]  # ty: ignore[invalid-method-override]  # noqa: ARG002
-        parts = self._rpath.parts
-        prefix = '' if len(parts) == 0 else ('/'.join(parts) + '/')
-        full_pattern = prefix + pattern
-        for p, node in self._nodes.items():
-            if not fnmatch.fnmatch(p, full_pattern):
-                continue
-            rpath = Path(*p.split('/'))
-            yield TarPath(tar=self.tar, _nodes=self._nodes, _rpath=rpath, _node=node)
+    def glob(self, pattern: str | os.PathLike[str], **kwargs) -> Iterator[TarPath]:  # type: ignore[override, unused-ignore]  # ty: ignore[invalid-method-override]
+        yield from archive_glob(self, pattern, recursive=False, **kwargs)
 
-    def rglob(self, pattern: str, **kwargs) -> Iterator[TarPath]:  # type: ignore[override, unused-ignore]  # ty: ignore[invalid-method-override]  # noqa: ARG002
-        parts = self._rpath.parts
-        prefix = '' if len(parts) == 0 else ('/'.join(parts) + '/')
-        for p, node in self._nodes.items():
-            if not p.startswith(prefix):
-                continue
-            rest = p[len(prefix) :]
-            if rest == '' or not Path(rest).match(pattern):
-                continue
-            rpath = Path(*p.split('/'))
-            yield TarPath(tar=self.tar, _nodes=self._nodes, _rpath=rpath, _node=node)
+    def rglob(self, pattern: str | os.PathLike[str], **kwargs) -> Iterator[TarPath]:  # type: ignore[override, unused-ignore]  # ty: ignore[invalid-method-override]
+        yield from archive_glob(self, pattern, recursive=True, **kwargs)
 
     def relative_to(self, other: TarPath, *extra: str | os.PathLike[str]) -> Path:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         assert _tarpath(self.tar) == _tarpath(other.tar), (_tarpath(self.tar), _tarpath(other.tar))
@@ -223,22 +207,33 @@ class TarPath(Path):
         sep = '/'  # note: doesn't really matter which separator is used here, this is just within this function
 
         members = tf.getmembers()
-        paths = []
-        infos = {}
+        infos: dict[str, TarInfo] = {}
         for m in members:
-            is_dir = m.isdir()
-
             norm_name = m.name
-            if norm_name == '.':
+            while norm_name.startswith('./'):
+                # Archives created against the current directory often prefix every member with "./".
+                norm_name = norm_name[2:]
+            if m.isdir():
+                norm_name = norm_name.rstrip('/')
+            if norm_name in {'', '.'}:
                 # sometimes root is included? we don't need it for walk_paths
                 continue
-            if norm_name[:2] == './':
-                # sometimes archive is created against current dir (.), this ends up with awkward dots in the index...
-                norm_name = norm_name[2:]
 
-            p = norm_name + (sep if is_dir else '')
-            paths.append(p)
             infos[norm_name] = m
+
+            # Tar archives need not contain explicit entries for parent directories.
+            # Synthesize them so a member such as "nested/file" still produces a navigable tree.
+            parts = norm_name.split(sep)
+            for end in range(1, len(parts)):
+                parent = sep.join(parts[:end])
+                if parent in infos:
+                    continue
+                parent_info = TarInfo(name=parent)
+                parent_info.type = tarfile.DIRTYPE
+                infos[parent] = parent_info
+
+        # walk_paths expects a depth-first-compatible order and explicit directory entries.
+        paths = sorted(f'{name}{sep}' if info.isdir() else name for name, info in infos.items())
 
         nodes: dict[str, Node] = {}
 

--- a/src/kompress/tests/archive_path.py
+++ b/src/kompress/tests/archive_path.py
@@ -45,6 +45,21 @@ GDPR_EXPORT_ENTRIES: ArchiveEntries = {
 }  # fmt: skip
 
 
+PATTERN_ENTRIES: ArchiveEntries = {
+    'root/'                       : None,
+    'root/empty_dir/'             : None,
+    'root/file.txt'               : b'file',
+    'root/aaa/'                   : None,
+    'root/aaa/bbb.txt'            : b'bbb',
+    'root/aaa/ccc/'               : None,
+    'root/aaa/ccc/ddd.json'       : b'{}',
+    'root/messages/'              : None,
+    'root/messages/index.csv'     : b'index',
+    'root/profile/'               : None,
+    'root/profile/settings.json'  : b'{}',
+}  # fmt: skip
+
+
 def _write_directory(target: Path, entries: ArchiveEntries) -> Path:
     target.mkdir()
     for name, data in entries.items():
@@ -217,6 +232,32 @@ def test_dot_segments(gdpr_export: Path) -> None:
     assert (gdpr_export / 'gdpr_export' / './comments').exists()
 
 
+def test_implicit_parent_directories(path_factory: Callable[[ArchiveEntries], Path]) -> None:
+    """
+    Archive formats can store a nested file without separate entries for its parent directories.
+    Archive-backed paths should synthesize those directories and expose the same tree as pathlib.
+    """
+    archive = path_factory(
+        {
+            'nested/deeper/file.txt': b'data',
+        }
+    )
+
+    nested = archive / 'nested'
+    deeper = nested / 'deeper'
+    file = deeper / 'file.txt'
+
+    assert nested.is_dir()
+    assert deeper.is_dir()
+    assert file.is_file()
+    assert file.read_bytes() == b'data'
+    assert _normalized_walk(archive) == [
+        (Path()               , ['nested'], []),
+        (Path('nested')       , ['deeper'], []),
+        (Path('nested/deeper'), []        , ['file.txt']),
+    ]  # fmt: skip
+
+
 def test_walk_empty(path_factory: Callable[[ArchiveEntries], Path]) -> None:
     archive = path_factory({})
 
@@ -307,6 +348,16 @@ def test_parent_joinpath_glob(gdpr_export: Path) -> None:
     assert all(isinstance(p, archive_path_type) for p in matched)
 
 
+def test_glob_star_is_not_recursive(gdpr_export: Path) -> None:
+    root = gdpr_export / 'gdpr_export'
+
+    assert sorted(path.relative_to(root) for path in root.glob('*')) == [
+        Path('comments'),
+        Path('messages'),
+        Path('profile'),
+    ]
+
+
 def test_file_type_methods(gdpr_export: Path) -> None:
     assert gdpr_export.exists()
     assert gdpr_export.is_dir()
@@ -388,6 +439,111 @@ def test_path_identity_and_ordering(gdpr_export: Path) -> None:
 @pytest.mark.parametrize(
     ('pattern', 'expected'),
     [
+        ('*'          , ['aaa', 'empty_dir', 'file.txt', 'messages', 'profile']),
+        ('*.txt'      , ['file.txt']),
+        ('aaa/*'      , ['aaa/bbb.txt', 'aaa/ccc']),
+        ('*/*.json'   , ['profile/settings.json']),
+        ('**/*.json'  , ['aaa/ccc/ddd.json', 'profile/settings.json']),
+        ('**/file.txt', ['file.txt']),
+        ('*/'         , ['aaa', 'empty_dir', 'messages', 'profile']),
+    ],
+)  # fmt: skip
+def test_glob_patterns(
+    path_factory: Callable[[ArchiveEntries], Path],
+    pattern: str,
+    expected: list[str],
+) -> None:
+    root = path_factory(PATTERN_ENTRIES) / 'root'
+
+    assert sorted(p.relative_to(root) for p in root.glob(pattern)) == [Path(p) for p in expected]
+
+
+@pytest.mark.parametrize(
+    ('method', 'expected'),
+    [
+        ('glob' , ['file.txt']),
+        ('rglob', ['aaa/bbb.txt', 'file.txt']),
+    ],
+)  # fmt: skip
+def test_pathlike_glob_pattern(
+    path_factory: Callable[[ArchiveEntries], Path],
+    method: str,
+    expected: list[str],
+) -> None:
+    """Archive paths accept path-like glob patterns on every supported Python version."""
+    root = path_factory(PATTERN_ENTRIES) / 'root'
+    if not isinstance(root, (TarPath, ZipPath)) and sys.version_info[:2] < (3, 13):
+        pytest.skip('pathlib.Path requires Python 3.13+ for path-like glob patterns')
+
+    matches = getattr(root, method)(Path('*.txt'))
+    assert sorted(p.relative_to(root) for p in matches) == [Path(p) for p in expected]
+
+
+@pytest.mark.parametrize(
+    ('method', 'pattern', 'expected_before_313', 'expected_from_313'),
+    [
+        (
+            'glob',
+            '**',
+            ['.', 'aaa', 'aaa/ccc', 'empty_dir', 'messages', 'profile'],
+            [
+                '.',
+                'aaa',
+                'aaa/bbb.txt',
+                'aaa/ccc',
+                'aaa/ccc/ddd.json',
+                'empty_dir',
+                'file.txt',
+                'messages',
+                'messages/index.csv',
+                'profile',
+                'profile/settings.json',
+            ],
+        ),
+        (
+            'glob',
+            'aaa/**',
+            ['aaa', 'aaa/ccc'],
+            ['aaa', 'aaa/bbb.txt', 'aaa/ccc', 'aaa/ccc/ddd.json'],
+        ),
+        (
+            'rglob',
+            '**',
+            ['.', 'aaa', 'aaa/ccc', 'empty_dir', 'messages', 'profile'],
+            [
+                '.',
+                'aaa',
+                'aaa/bbb.txt',
+                'aaa/ccc',
+                'aaa/ccc/ddd.json',
+                'empty_dir',
+                'file.txt',
+                'messages',
+                'messages/index.csv',
+                'profile',
+                'profile/settings.json',
+            ],
+        ),
+    ],
+)
+def test_terminal_recursive_glob(
+    path_factory: Callable[[ArchiveEntries], Path],
+    method: str,
+    pattern: str,
+    expected_before_313: list[str],
+    expected_from_313: list[str],
+) -> None:
+    """A terminal ``**`` also matches files starting with Python 3.13."""
+    root = path_factory(PATTERN_ENTRIES) / 'root'
+    expected = expected_from_313 if sys.version_info[:2] >= (3, 13) else expected_before_313
+
+    matches = getattr(root, method)(pattern)
+    assert sorted(p.relative_to(root) for p in matches) == [Path(p) for p in expected]
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'expected'),
+    [
         (
             '*',
             [
@@ -450,22 +606,15 @@ def test_rglob_patterns(
     pattern: str,
     expected: list[str],
 ) -> None:
-    entries: ArchiveEntries = {
-        'root/'                       : None,
-        'root/empty_dir/'             : None,
-        'root/file.txt'               : b'file',
-        'root/aaa/'                   : None,
-        'root/aaa/bbb.txt'            : b'bbb',
-        'root/aaa/ccc/'               : None,
-        'root/aaa/ccc/ddd.json'       : b'{}',
-        'root/messages/'              : None,
-        'root/messages/index.csv'     : b'index',
-        'root/profile/'               : None,
-        'root/profile/settings.json'  : b'{}',
-    }  # fmt: skip
-    root = path_factory(entries)
+    root = path_factory(PATTERN_ENTRIES)
 
     assert sorted(p.relative_to(root) for p in root.rglob(pattern)) == [Path(p) for p in expected]
+
+
+def test_rglob_from_subdirectory(path_factory: Callable[[ArchiveEntries], Path]) -> None:
+    root = path_factory(PATTERN_ENTRIES) / 'root' / 'aaa'
+
+    assert [p.relative_to(root) for p in root.rglob('*.json')] == [Path('ccc/ddd.json')]
 
 
 @pytest.mark.parametrize('filename', ['missing.zip', *(f'missing.{kind}' for kind in TAR_ARCHIVE_KINDS)])

--- a/src/kompress/utils.py
+++ b/src/kompress/utils.py
@@ -4,9 +4,87 @@ Helper utils for zippath adapter
 
 from __future__ import annotations
 
+import fnmatch
 import os
+import sys
 from collections.abc import Iterable, Iterator
 from pathlib import Path
+from typing import Protocol, Self
+
+
+class _GlobPath(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    def is_dir(self) -> bool: ...
+
+    def iterdir(self) -> Iterator[Self]: ...
+
+
+def archive_glob[GlobPathT: _GlobPath](
+    root: GlobPathT,
+    pattern: str | os.PathLike[str],
+    *,
+    recursive: bool,
+    **kwargs,
+) -> Iterator[GlobPathT]:
+    case_sensitive: bool | None = kwargs.pop('case_sensitive', None)
+    kwargs.pop('recurse_symlinks', False)
+    if kwargs:
+        unexpected = next(iter(kwargs))
+        raise TypeError(f"glob() got an unexpected keyword argument {unexpected!r}")
+
+    pattern_str = os.fspath(pattern)
+    if pattern_str == '':
+        raise ValueError("Unacceptable pattern: ''")
+
+    pattern_path = Path(pattern_str)
+    if pattern_path.is_absolute():
+        raise NotImplementedError("Non-relative patterns are unsupported")
+
+    # Repeating os.sep when os.altsep is unavailable avoids platform-specific optional typing.
+    separators = (os.sep, os.altsep or os.sep)
+    directory_only = pattern_str.endswith(separators)
+    pattern_parts = pattern_path.parts
+    if recursive:
+        pattern_parts = ('**', *pattern_parts)
+
+    def matches(name: str, part: str) -> bool:
+        if case_sensitive is None:
+            return fnmatch.fnmatch(name, part)
+        if case_sensitive:
+            return fnmatch.fnmatchcase(name, part)
+        return fnmatch.fnmatchcase(name.casefold(), part.casefold())
+
+    # Each state is handled once, preventing repeated `**` components from doing duplicate work.
+    states: list[tuple[GlobPathT, int]] = [(root, 0)]
+    visited: set[tuple[GlobPathT, int]] = set()
+    while states:
+        current, pattern_pos = states.pop()
+        state = (current, pattern_pos)
+        if state in visited:
+            continue
+        visited.add(state)
+
+        if pattern_pos == len(pattern_parts):
+            if not directory_only or current.is_dir():
+                yield current
+            continue
+        if not current.is_dir():
+            continue
+
+        part = pattern_parts[pattern_pos]
+        children = list(current.iterdir())
+        if part == '**':
+            # Add descendants first so the zero-segment state is popped and handled first.
+            states.extend((child, pattern_pos) for child in reversed(children) if child.is_dir())
+            if pattern_pos == len(pattern_parts) - 1 and sys.version_info[:2] >= (3, 13):
+                # Since Python 3.13, a terminal `**` yields files as well as directories.
+                states.extend((child, pattern_pos + 1) for child in reversed(children))
+            states.append((current, pattern_pos + 1))
+        else:
+            states.extend((child, pattern_pos + 1) for child in reversed(children) if matches(child.name, part))
+
 
 RootName = str
 DirName = str

--- a/src/kompress/zip.py
+++ b/src/kompress/zip.py
@@ -9,7 +9,7 @@ from functools import total_ordering
 from pathlib import Path
 from typing import Self
 
-from .utils import walk_paths
+from .utils import archive_glob, walk_paths
 
 
 def _without_dot_segments(at: str) -> str:
@@ -92,12 +92,11 @@ class ZipPath(zipfile.Path):
     def _next(self, at: str) -> ZipPath:
         return ZipPath(self.root, at)
 
-    def rglob(self, pattern: str) -> Iterator[ZipPath]:
-        # note: not 100% sure about the correctness, but seem fine?
-        # Path.match() matches from the right, so need to
-        rpaths = (p for p in self.root.namelist() if p.startswith(self.at))
-        rpaths = (p for p in rpaths if Path(p).match(pattern))
-        return (ZipPath(self.root, p) for p in rpaths)
+    def glob(self, pattern: str | os.PathLike[str], **kwargs) -> Iterator[ZipPath]:
+        yield from archive_glob(self, pattern, recursive=False, **kwargs)
+
+    def rglob(self, pattern: str | os.PathLike[str], **kwargs) -> Iterator[ZipPath]:
+        yield from archive_glob(self, pattern, recursive=True, **kwargs)
 
     def relative_to(self, other: ZipPath, *extra: str | os.PathLike[str]) -> Path:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         assert self.filepath == other.filepath, (self.filepath, other.filepath)


### PR DESCRIPTION
- share pathlib-like glob and rglob matching across zip and tar paths
- synthesize missing parent directories in tar archives
- expand cross-backend traversal and glob coverage
- refresh README usage and supported-format documentation